### PR TITLE
identify is better than name_tag

### DIFF
--- a/metron/templates/metron/_mixpanel.html
+++ b/metron/templates/metron/_mixpanel.html
@@ -2,7 +2,7 @@
 typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.track_charge people.clear_charges people.delete_user".split(" ");for(g=0;g<i.length;g++)f(c,i[g]);
 b._i.push([a,e,d])};b.__SV=1.2}})(document,window.mixpanel||[]);
 mixpanel.init("{{ code }}");
-{% if user.is_authenticated %}mixpanel.name_tag("{{ user.username }}");{% endif %}
+{% if user.is_authenticated %}mixpanel.identify("{{ user.pk }}");{% endif %}
 {% for action in actions %}
     mixpanel.{{ action.method }}(
         {% for arg in action.args %}


### PR DESCRIPTION
`name_tag` won't uniqueley set the identifier. You should call `identify` for that.

https://mixpanel.com/docs/integration-libraries/javascript-full-api#name_tag
https://mixpanel.com/docs/integration-libraries/javascript-full-api#identify
